### PR TITLE
fix: isOwner compare ownerId with current userId

### DIFF
--- a/app/pets/[id]/members/index.tsx
+++ b/app/pets/[id]/members/index.tsx
@@ -1,0 +1,135 @@
+import { MemberCard } from "@/components/MemberCard";
+import { usePetMembersScreen } from "@/hooks/usePetMembersScreen";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  View,
+} from "react-native";
+
+const colors = {
+  light: {
+    background: "#FFF0F5",
+    cardBackground: "#ffffff",
+    text: "#333",
+    textSecondary: "#666",
+    textTertiary: "#999",
+    tint: "#D4517A",
+  },
+  dark: {
+    background: "#1a0d12",
+    cardBackground: "#2a1520",
+    text: "#ffffff",
+    textSecondary: "#aaaaaa",
+    textTertiary: "#777",
+    tint: "#F07098",
+  },
+};
+
+export default function PetMembersScreen() {
+  const colorScheme = useColorScheme();
+  const theme = colors[colorScheme ?? "light"];
+  const { pet, shares, isLoading, handleRemoveMember, handleInvitePress } =
+    usePetMembersScreen();
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: pet ? `${pet.name} — Members` : "Members",
+          headerRight: () => (
+            <Pressable style={styles.headerButton} onPress={handleInvitePress}>
+              <Ionicons name="person-add-outline" size={22} color={theme.tint} />
+            </Pressable>
+          ),
+        }}
+      />
+      <ScrollView
+        style={[styles.container, { backgroundColor: theme.background }]}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>
+            Members with access
+          </Text>
+
+          {isLoading ? (
+            <ActivityIndicator size="small" color={theme.tint} style={styles.loader} />
+          ) : shares.length === 0 ? (
+            <View style={[styles.empty, { backgroundColor: theme.cardBackground }]}>
+              <Ionicons name="people-outline" size={36} color={theme.textTertiary} />
+              <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+                No members yet
+              </Text>
+              <Text style={[styles.emptySubtext, { color: theme.textTertiary }]}>
+                Tap the + button to invite someone
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.list}>
+              {shares.map((share) => (
+                <MemberCard
+                  key={share.id}
+                  share={share}
+                  onRemove={() =>
+                    handleRemoveMember(
+                      share.memberId,
+                      share.memberDisplayName ?? share.memberEmail ?? share.memberId,
+                    )
+                  }
+                />
+              ))}
+            </View>
+          )}
+        </View>
+
+        <Pressable
+          style={[styles.inviteButton, { backgroundColor: theme.tint }]}
+          onPress={handleInvitePress}
+        >
+          <Ionicons name="person-add-outline" size={20} color="#fff" />
+          <Text style={styles.inviteButtonText}>Invite someone</Text>
+        </Pressable>
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerButton: { width: 36, height: 36, justifyContent: "center", alignItems: "center" },
+  section: { marginTop: 24, paddingHorizontal: 16 },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 10,
+  },
+  loader: { marginTop: 24 },
+  list: { gap: 8 },
+  empty: {
+    borderRadius: 12,
+    padding: 32,
+    alignItems: "center",
+    gap: 8,
+  },
+  emptyText: { fontSize: 16, fontWeight: "500" },
+  emptySubtext: { fontSize: 14, textAlign: "center" },
+  inviteButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    margin: 16,
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 12,
+  },
+  inviteButtonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+});

--- a/app/pets/[id]/members/invite.tsx
+++ b/app/pets/[id]/members/invite.tsx
@@ -1,0 +1,148 @@
+import { useInviteMemberScreen } from "@/hooks/useInviteMemberScreen";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  useColorScheme,
+  View,
+} from "react-native";
+
+const colors = {
+  light: {
+    background: "#FFF0F5",
+    cardBackground: "#ffffff",
+    text: "#333",
+    textSecondary: "#666",
+    textTertiary: "#999",
+    tint: "#D4517A",
+    inputBorder: "#e0c0cc",
+  },
+  dark: {
+    background: "#1a0d12",
+    cardBackground: "#2a1520",
+    text: "#ffffff",
+    textSecondary: "#aaaaaa",
+    textTertiary: "#777",
+    tint: "#F07098",
+    inputBorder: "#4a2535",
+  },
+};
+
+export default function InviteMemberScreen() {
+  const colorScheme = useColorScheme();
+  const theme = colors[colorScheme ?? "light"];
+  const { email, setEmail, isLoading, handleSubmit } = useInviteMemberScreen();
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Invite Member" }} />
+      <KeyboardAvoidingView
+        style={[styles.container, { backgroundColor: theme.background }]}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <View style={styles.content}>
+          <View style={[styles.iconContainer, { backgroundColor: "#fce4ec" }]}>
+            <Ionicons name="person-add-outline" size={36} color={theme.tint} />
+          </View>
+
+          <Text style={[styles.title, { color: theme.text }]}>
+            Invite someone
+          </Text>
+          <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
+            They'll receive an invitation to access this pet's data.
+          </Text>
+
+          <View
+            style={[
+              styles.inputContainer,
+              { backgroundColor: theme.cardBackground, borderColor: theme.inputBorder },
+            ]}
+          >
+            <Ionicons name="mail-outline" size={20} color={theme.textTertiary} />
+            <TextInput
+              style={[styles.input, { color: theme.text }]}
+              placeholder="Email address"
+              placeholderTextColor={theme.textTertiary}
+              value={email}
+              onChangeText={setEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              returnKeyType="send"
+              onSubmitEditing={handleSubmit}
+            />
+          </View>
+
+          <Pressable
+            style={[
+              styles.sendButton,
+              { backgroundColor: theme.tint },
+              isLoading && styles.sendButtonDisabled,
+            ]}
+            onPress={handleSubmit}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <>
+                <Ionicons name="send-outline" size={18} color="#fff" />
+                <Text style={styles.sendButtonText}>Send Invitation</Text>
+              </>
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: "center",
+    paddingHorizontal: 24,
+    paddingTop: 40,
+  },
+  iconContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 20,
+  },
+  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
+  subtitle: { fontSize: 15, textAlign: "center", marginBottom: 32, lineHeight: 22 },
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    width: "100%",
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 4,
+    gap: 10,
+    marginBottom: 16,
+  },
+  input: { flex: 1, fontSize: 16, paddingVertical: 12 },
+  sendButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    width: "100%",
+    padding: 16,
+    borderRadius: 12,
+  },
+  sendButtonDisabled: { opacity: 0.6 },
+  sendButtonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+});

--- a/components/MemberCard.tsx
+++ b/components/MemberCard.tsx
@@ -1,0 +1,68 @@
+import type { PetShare } from "@/db/schema";
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, StyleSheet, Text, useColorScheme, View } from "react-native";
+
+type Props = {
+  share: PetShare;
+  onRemove?: () => void;
+};
+
+export function MemberCard({ share, onRemove }: Props) {
+  const isDark = useColorScheme() === "dark";
+  const cardBg = isDark ? "#2a1520" : "#ffffff";
+  const text = isDark ? "#ffffff" : "#333";
+  const textSecondary = isDark ? "#aaaaaa" : "#666";
+  const tint = isDark ? "#F07098" : "#D4517A";
+
+  const displayName = share.memberDisplayName ?? share.memberEmail ?? share.memberId;
+  const subtitle = share.memberDisplayName ? share.memberEmail : null;
+
+  return (
+    <View style={[styles.card, { backgroundColor: cardBg }]}>
+      <View style={styles.avatar}>
+        <Ionicons name="person" size={22} color={tint} />
+      </View>
+      <View style={styles.info}>
+        <Text style={[styles.name, { color: text }]} numberOfLines={1}>
+          {displayName}
+        </Text>
+        {subtitle && (
+          <Text style={[styles.email, { color: textSecondary }]} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        )}
+      </View>
+      {onRemove && (
+        <Pressable
+          onPress={onRemove}
+          hitSlop={8}
+          style={({ pressed }) => [styles.removeButton, pressed && { opacity: 0.6 }]}
+        >
+          <Ionicons name="person-remove-outline" size={20} color="#FF3B30" />
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 12,
+    padding: 14,
+    gap: 12,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#fce4ec",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  info: { flex: 1 },
+  name: { fontSize: 16, fontWeight: "500" },
+  email: { fontSize: 13, marginTop: 2 },
+  removeButton: { padding: 4 },
+});

--- a/hooks/useInviteMemberScreen.ts
+++ b/hooks/useInviteMemberScreen.ts
@@ -1,0 +1,36 @@
+import { useInviteMember } from "@/hooks/usePetShares";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useCallback, useState } from "react";
+import { Alert } from "react-native";
+
+export function useInviteMemberScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [email, setEmail] = useState("");
+
+  const inviteMutation = useInviteMember();
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed || !trimmed.includes("@")) {
+      Alert.alert("Invalid email", "Please enter a valid email address.");
+      return;
+    }
+
+    try {
+      await inviteMutation.mutateAsync({ petId: id, email: trimmed });
+      Alert.alert("Invitation sent", `An invitation has been sent to ${trimmed}.`, [
+        { text: "OK", onPress: () => router.back() },
+      ]);
+    } catch {
+      Alert.alert("Error", "Could not send the invitation. Please try again.");
+    }
+  }, [email, id, inviteMutation, router]);
+
+  return {
+    email,
+    setEmail,
+    isLoading: inviteMutation.isPending,
+    handleSubmit,
+  };
+}

--- a/hooks/usePetDetailScreen.ts
+++ b/hooks/usePetDetailScreen.ts
@@ -18,12 +18,14 @@ import {
   useMarkVisitComplete,
   useVisitsByPet,
 } from "@/hooks/useVisits";
+import { useAuth } from "@/context/AuthContext";
 import { calculateAge } from "@/lib/petAge";
 import { syncWithSupabase } from "@/services/sync";
 
 export function usePetDetailScreen() {
   const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
+  const { user } = useAuth();
 
   const { data: pet, isLoading: isPetLoading } = usePet(id);
   const { data: visits = [], isLoading: isVisitsLoading } = useVisitsByPet(id);
@@ -174,7 +176,7 @@ export function usePetDetailScreen() {
     [visits, markCompleteMutation],
   );
 
-  const isOwner = !pet?.ownerId;
+  const isOwner = !pet?.ownerId || pet.ownerId === user?.id;
 
   const handleEditPress = useCallback(() => {
     router.push(`/pets/${id}/edit`);

--- a/hooks/usePetMembersScreen.ts
+++ b/hooks/usePetMembersScreen.ts
@@ -1,0 +1,47 @@
+import { usePetShares, useRemoveMember } from "@/hooks/usePetShares";
+import { usePet } from "@/hooks/usePets";
+import * as Haptics from "expo-haptics";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useCallback } from "react";
+import { Alert } from "react-native";
+
+export function usePetMembersScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const { data: pet } = usePet(id);
+  const { data: shares = [], isLoading } = usePetShares(id);
+  const removeMemberMutation = useRemoveMember();
+
+  const handleRemoveMember = useCallback(
+    (memberId: string, displayName: string) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      Alert.alert(
+        "Remove Member",
+        `Remove ${displayName} from ${pet?.name ?? "this pet"}?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Remove",
+            style: "destructive",
+            onPress: () =>
+              removeMemberMutation.mutate({ petId: id, memberId }),
+          },
+        ],
+      );
+    },
+    [id, pet?.name, removeMemberMutation],
+  );
+
+  const handleInvitePress = useCallback(() => {
+    router.push(`/pets/${id}/members/invite`);
+  }, [id, router]);
+
+  return {
+    pet,
+    shares,
+    isLoading,
+    handleRemoveMember,
+    handleInvitePress,
+  };
+}


### PR DESCRIPTION
## Summary

`ownerId` siempre está poblado tras la sincronización (`remote.owner_id ?? user_id`), por lo que `!pet.ownerId` era siempre `false` y el botón "Manage Members" nunca aparecía.

Fix: `isOwner = !pet.ownerId || pet.ownerId === user.id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)